### PR TITLE
Setting up keymap toggling

### DIFF
--- a/data/piwiz.ui
+++ b/data/piwiz.ui
@@ -316,7 +316,7 @@ Press 'Next' to get started. </property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="label" translatable="yes">Use US keyboard</property>
-                            <property name="tooltip_text" translatable="yes">Use the US keyboard layout instead of the default keyboard for your country</property>
+                            <property name="tooltip_text" translatable="yes">Use the US keyboard layout with default keyboard for your country</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>

--- a/src/piwiz.c
+++ b/src/piwiz.c
@@ -1179,7 +1179,7 @@ static void next_page (GtkButton* btn, gpointer ptr)
 
                             if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (us_key)))
                             {
-                                lay = g_strdup_printf("us,%s", lay);
+                                lay = g_strdup_printf("us,%s", g_strdup(lay));
                                 var = g_strdup ("");
                                 opt = g_strdup ("grp:alt_shift_toggle");
                             }

--- a/src/piwiz.c
+++ b/src/piwiz.c
@@ -1199,7 +1199,7 @@ static void next_page (GtkButton* btn, gpointer ptr)
                                 || g_strcmp0 (init_lang, lc) || g_ascii_strcasecmp (init_kb, lay)
                                 || g_strcmp0 (init_var, var))
                             {
-                                opt = g_strdup("");
+                                opt = g_strdup(" ");
                                 message (_("Setting location - please wait..."), 0, 0, -1, TRUE);
                                 g_thread_new (NULL, set_locale, NULL);
                             }

--- a/src/piwiz.c
+++ b/src/piwiz.c
@@ -718,7 +718,7 @@ static void read_inits (void)
     init_tz = get_string ("cat /etc/timezone");
     init_kb = get_string ("grep XKBLAYOUT /etc/default/keyboard | cut -d = -f 2 | tr -d '\"\n'");
     init_var = get_string ("grep XKBVARIANT /etc/default/keyboard | cut -d = -f 2 | tr -d '\"\n'");
-    init_opt = get_string ("grep XKBVARIANT /etc/default/keyboard | cut -d = -f 2 | tr -d '\"\n'");
+    init_opt = get_string ("grep XKBOPTIONS /etc/default/keyboard | cut -d = -f 2 | tr -d '\"\n'");
     buffer = get_string ("grep LC_ALL /etc/default/locale | cut -d = -f 2");
     if (!buffer[0]) buffer = get_string ("grep LANGUAGE /etc/default/locale | cut -d = -f 2");
     if (!buffer[0]) buffer = get_string ("grep LANG /etc/default/locale | cut -d = -f 2");

--- a/src/piwiz.c
+++ b/src/piwiz.c
@@ -1179,7 +1179,7 @@ static void next_page (GtkButton* btn, gpointer ptr)
 
                             if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (us_key)))
                             {
-                                lay = g_strdup_printf(("us,%s", lay));
+                                lay = g_strdup_printf("us,%s", lay);
                                 var = g_strdup ("");
                                 opt = g_strdup ("grp:alt_shift_toggle");
                             }

--- a/src/piwiz.c
+++ b/src/piwiz.c
@@ -1177,13 +1177,15 @@ static void next_page (GtkButton* btn, gpointer ptr)
                             gtk_combo_box_get_active_iter (GTK_COMBO_BOX (timezone_cb), &iter);
                             gtk_tree_model_get (model, &iter, 0, &city, -1);
 
+                            lookup_keyboard (cc, lc, &lay, &var);
+
                             if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (us_key)))
                             {
                                 lay = g_strdup_printf("us,%s", g_strdup(lay));
                                 var = g_strdup ("");
                                 opt = g_strdup ("grp:alt_shift_toggle");
                             }
-                            else lookup_keyboard (cc, lc, &lay, &var);
+
 
                             // set wifi country - this is quick, so no need for warning
                             if (wifi_if[0])

--- a/src/piwiz.c
+++ b/src/piwiz.c
@@ -86,8 +86,8 @@ GtkListStore *ap_list;
 
 /* Globals */
 
-char *wifi_if, *init_country, *init_lang, *init_kb, *init_var, *init_tz;
-char *cc, *lc, *city, *ext, *lay, *var;
+char *wifi_if, *init_country, *init_lang, *init_kb, *init_var, *init_opt, *init_tz;
+char *cc, *lc, *city, *ext, *lay, *var, *opt;
 char *ssid;
 gint conn_timeout = 0, pulse_timer = 0;
 gboolean reboot;
@@ -503,10 +503,10 @@ static gpointer set_locale (gpointer data)
         fp = fopen ("/etc/default/keyboard", "wb");
         if (fp)
         {
-            fprintf (fp, "XKBMODEL=pc105\nXKBLAYOUT=%s\nXKBVARIANT=%s\nXKBOPTIONS=\nBACKSPACE=guess", lay, var);
+            fprintf (fp, "XKBMODEL=pc105\nXKBLAYOUT=%s\nXKBVARIANT=%s\nXKBOPTIONS=%s\nBACKSPACE=guess", lay, var, opt);
             fclose (fp);
         }
-        vsystem ("setxkbmap -layout %s -variant \"%s\" -option \"\"", lay, var);
+        vsystem ("setxkbmap -layout %s -variant \"%s\" -option \"%s\"", lay, var, opt);
         if (init_kb)
         {
             g_free (init_kb);
@@ -516,6 +516,11 @@ static gpointer set_locale (gpointer data)
         {
             g_free (init_var);
             init_var = g_strdup (var);
+        }
+        if (init_opt)
+        {
+            g_free (init_opt);
+            init_opt = g_strdup (opt);
         }
     }
 
@@ -712,6 +717,7 @@ static void read_inits (void)
     init_tz = get_string ("cat /etc/timezone");
     init_kb = get_string ("grep XKBLAYOUT /etc/default/keyboard | cut -d = -f 2 | tr -d '\"\n'");
     init_var = get_string ("grep XKBVARIANT /etc/default/keyboard | cut -d = -f 2 | tr -d '\"\n'");
+    init_opt = get_string ("grep XKBVARIANT /etc/default/keyboard | cut -d = -f 2 | tr -d '\"\n'");
     buffer = get_string ("grep LC_ALL /etc/default/locale | cut -d = -f 2");
     if (!buffer[0]) buffer = get_string ("grep LANGUAGE /etc/default/locale | cut -d = -f 2");
     if (!buffer[0]) buffer = get_string ("grep LANG /etc/default/locale | cut -d = -f 2");
@@ -1173,8 +1179,9 @@ static void next_page (GtkButton* btn, gpointer ptr)
 
                             if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (us_key)))
                             {
-                                lay = g_strdup ("us");
+                                lay = g_strdup ("us,%s", lay);
                                 var = g_strdup ("");
+                                opt = g_strdup ("grp:alt_shift_toggle");
                             }
                             else lookup_keyboard (cc, lc, &lay, &var);
 

--- a/src/piwiz.c
+++ b/src/piwiz.c
@@ -1179,7 +1179,7 @@ static void next_page (GtkButton* btn, gpointer ptr)
 
                             if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (us_key)))
                             {
-                                lay = g_strdup ("us,%s", lay);
+                                lay = g_strdup (("us,%s", lay));
                                 var = g_strdup ("");
                                 opt = g_strdup ("grp:alt_shift_toggle");
                             }

--- a/src/piwiz.c
+++ b/src/piwiz.c
@@ -1179,7 +1179,7 @@ static void next_page (GtkButton* btn, gpointer ptr)
 
                             if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (us_key)))
                             {
-                                lay = g_strdup (("us,%s", lay));
+                                lay = g_strdup_printf(("us,%s", lay));
                                 var = g_strdup ("");
                                 opt = g_strdup ("grp:alt_shift_toggle");
                             }

--- a/src/piwiz.c
+++ b/src/piwiz.c
@@ -546,6 +546,7 @@ static gpointer set_locale (gpointer data)
 
     g_free (lay);
     g_free (var);
+    g_free (opt);
     g_free (city);
     g_free (ext);
 

--- a/src/piwiz.c
+++ b/src/piwiz.c
@@ -1199,6 +1199,7 @@ static void next_page (GtkButton* btn, gpointer ptr)
                                 || g_strcmp0 (init_lang, lc) || g_ascii_strcasecmp (init_kb, lay)
                                 || g_strcmp0 (init_var, var))
                             {
+                                opt = g_strdup("");
                                 message (_("Setting location - please wait..."), 0, 0, -1, TRUE);
                                 g_thread_new (NULL, set_locale, NULL);
                             }


### PR DESCRIPTION
### History
At version from Raspbian Stretch 2018-06-27 me and my russian friends got a console with russian symbols at console. And nothing could be done about it — comand prompt needs a latin symbols.

I see, that you made chekbox «Use US keyboard», but this is not very good, we need to have two layouts.

### Changes
The checkbox «Use US keyboard» now adds the US layout to the national and sets the keymap switch to shift+alt. 

### Code
Added variables _opt_ and _init_opt_ (as lay and init_kb), which control _XKBOPTIONS_ value at _/etc/default/keyboard_
Then was some changes at _case PAGE_LOCALE_ in _next_page_ void.
Also changed gui-template.

_Sorry for a lot of commits, we have some troubles with build and test servers._