### PR TITLE
Update max username length <= 30

### DIFF
--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -177,8 +177,8 @@ msgid "The username is blank."
 msgstr "The username is blank."
 
 #: ../src/piwiz.c:1638
-msgid "The username must be 32 characters or shorter."
-msgstr "The username must be 32 characters or shorter."
+msgid "The username must be 30 characters or shorter."
+msgstr "The username must be 30 characters or shorter."
 
 #: ../src/piwiz.c:1643
 msgid "The first character of the username must be a lower-case letter."

--- a/po/it.po
+++ b/po/it.po
@@ -178,8 +178,8 @@ msgid "The username is blank."
 msgstr "Il nome utente è vuoto."
 
 #: ../src/piwiz.c:1634
-msgid "The username must be 32 characters or shorter."
-msgstr "Il nome utente deve essere lungo al massimo di 32 caratteri."
+msgid "The username must be 30 characters or shorter."
+msgstr "Il nome utente deve essere lungo al massimo di 30 caratteri."
 
 #: ../src/piwiz.c:1639
 msgid "The first character of the username must be a lower-case letter."

--- a/po/ko.po
+++ b/po/ko.po
@@ -178,7 +178,7 @@ msgid "The username is blank."
 msgstr "사용자 이름을 입력하세요."
 
 #: ../src/piwiz.c:1638
-msgid "The username must be 32 characters or shorter."
+msgid "The username must be 30 characters or shorter."
 msgstr "사용자 이름은 32자 이하로 설정하세요."
 
 #: ../src/piwiz.c:1643

--- a/src/piwiz.c
+++ b/src/piwiz.c
@@ -2264,9 +2264,9 @@ static void next_page (GtkButton* btn, gpointer ptr)
                                 message (_("The username is blank."), 1, 0, -1, FALSE);
                                 break;
                             }
-                            if (strlen (ccptr) > 32)
+                            if (strlen (ccptr) => 30)
                             {
-                                message (_("The username must be 32 characters or shorter."), 1, 0, -1, FALSE);
+                                message (_("The username must be 30 characters or shorter."), 1, 0, -1, FALSE);
                                 break;
                             }
                             if (*ccptr < 'a' || *ccptr > 'z')


### PR DESCRIPTION
As discussed in [an PR from the documentation repo](https://github.com/raspberrypi/documentation/pull/3357) this changes the maximum username length to 30 characters.

Caveat: As I do not have a solid test environment I didn't test these small change.