### PR TITLE
Proposal: Force keyboard init

### DIFF
--- a/src/piwiz.c
+++ b/src/piwiz.c
@@ -524,6 +524,11 @@ static int get_pi_keyboard (void)
     int val, ret = 0;
     char *res;
 
+    if (getenv("PIWIZ_KBD_INIT"))
+    {
+        return 0;
+    }
+
     res = get_string ("hexdump -n 1 -s 3 -e '1/1 \"%d\"' /proc/device-tree/chosen/rpi-country-code 2> /dev/null");
     if (res)
     {


### PR DESCRIPTION
A very simple proposal to force keyboard detection that respects locale settings. I propose to merge or implement similar functionality. Use case: custom Raspberry Pi OS built by pi-gen where locale already set and piwiz should show the correct locale settings when the PIWIZ_KBD_INIT environment variable is set.